### PR TITLE
Add Validation Tests, clear(), and reset()

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,18 @@ When creating an instance of `MultiFieldView`, you can pass initial values to be
 - `fields`: an array of form-vield views
 - `value`: initial value to pass on to the MultiFieldView's forms. An object where the keys match the fields' `name` attributes.
 - `template`: a custom template to use.
-- `validCallback`: function called whenever the `valid` property's value changes.
+- `tests` (default `[]`): validation functions to run on the fields' values. See below.
 - `beforeSubmit`: function called by [ampersand-form-view][ampersand-form-view] during submit.
+- `validCallback`: function called whenever the `valid` property's value changes.
 
 ### render `AmpersandMultiFieldView.render()`
 Renders the MultiFieldView. Called automatically when used within a parent [ampersand-form-view][ampersand-form-view].
+
+### reset `AmpersandMultiFieldView.reset()`
+Reset the fields' values to their starting value
+
+### clear `AmpersandMultiFieldView.clear()`
+Clears the fields' values
 
 ### template `AmpersandMultiFieldView.template`
 This can be customized by using `extend` or by passing in a `template` on instantiation.
@@ -128,8 +135,29 @@ The resulting HTML should contain the following hooks:
 - an element with a `data-hook="label"` attribute.
 - an element with a `data-hook="multifields"` attribute where the fields are inserted.
 
-## validCallback `AmpersandMultiFieldView.validCallback()`
-A function that gets called, if it exists, when the field first loads and anytime the form changes from valid to invalid or vice versa.
+### tests `AmpersandMultiFieldView.tests`
+The test functions will be called in the context of the MultifieldView and receive the MultiFieldView's `value`.
+
+The tests should return an error message if invalid and return either a falsy value or not return otherwise.
+
+It's recommended that tests validatate the relationship of the fields. As an example, validate that when the address field has a value, that the zip code field does as well.
+
+```javascript
+var AmpersandMultiFieldView = require('ampersand-multifield-view');
+
+var MyCustomMultiField = AmpersandMultiFieldView.extend({
+  ...
+  tests: [
+    function(value) {
+      var hasAddrOrZip = !!value.address1 || !!value.zip;
+      var hasBoth = value.address && value.zip
+      if (hasAddrOrZip && !hasBoth) {
+        return 'An address and zip code must both be provided'
+      }
+    }
+  ]
+});
+```
 
 ### beforeSubmit `AmpersandMultiFieldView.beforeSubmit()`
 This function is called by [ampersand-form-view][ampersand-form-view] during submit and calls its fields' `beforeSubmit` functions.
@@ -140,6 +168,7 @@ This function is called by [ampersand-form-view][ampersand-form-view] during sub
 var AmpersandMultiFieldView = require('ampersand-multifield-view');
 
 var MyCustomMultiField = AmpersandMultiFieldView.extend({
+  ...
   beforeSubmit: function() {
     // call its parent's beforeSubmit manually
     AmpersandMultiFieldView.prototype.beforeSubmit.call(this);
@@ -148,6 +177,9 @@ var MyCustomMultiField = AmpersandMultiFieldView.extend({
   }
 });
 ```
+
+### validCallback `AmpersandMultiFieldView.validCallback()`
+A function that gets called, if it exists, when the field first loads and anytime the form changes from valid to invalid or vice versa.
 
 ## License
 

--- a/ampersand-multifield-view.js
+++ b/ampersand-multifield-view.js
@@ -4,12 +4,17 @@ var find = require('lodash.find');
 var View = require('ampersand-view');
 
 var MultiFieldView = View.extend({
+  /* jshint maxlen: false */
   template: [
     '<div>',
       '<p class="label" data-hook="label"></p>',
+      '<div data-hook="multi-message-container" class="message message-below message-error">',
+        '<p data-hook="multi-message-text"></p>',
+      '</div>',
       '<div data-hook="multifields"></div>',
     '</div>'
   ].join(''),
+  /* jshint maxlen: 80 */
 
   bindings: {
     'label': [
@@ -20,12 +25,31 @@ var MultiFieldView = View.extend({
         type: 'toggle',
         hook: 'label'
       }
-    ]
+    ],
+    'message': {
+      type: 'text',
+      hook: 'multi-message-text'
+    },
+    'showMessage': {
+      type: 'toggle',
+      hook: 'multi-message-container'
+    }
   },
 
   props: {
     label: ['string', true, ''],
-    name: 'string'
+    message: ['string', true, ''],
+    name: 'string',
+    shouldValidate: ['boolean', true, false]
+  },
+
+  derived: {
+    showMessage: {
+      deps: ['message', 'shouldValidate'],
+      fn: function() {
+        return this.shouldValidate && this.message;
+      }
+    }
   },
 
   initialize: function(spec) {
@@ -36,6 +60,7 @@ var MultiFieldView = View.extend({
     this.beforeSubmit = spec.beforeSubmit || this.beforeSubmit;
     this.fields = spec.fields || this.fields || [];
     this.name = spec.name;
+    this.tests = spec.tests || this.tests || [];
     this.validCallback = spec.validCallback || function() {};
     this.value = spec.value || {};
 
@@ -73,9 +98,25 @@ var MultiFieldView = View.extend({
   },
 
   isValid: function() {
-    return this.fields.every(function(field) {
+    var fieldsValid =  this.fields.every(function(field) {
       return field.valid;
     });
+
+    var valid = !this.runTests();
+
+    return fieldsValid && valid;
+  },
+
+  runTests: function() {
+    var errMsg = '';
+
+    this.tests.some(function(test) {
+      errMsg = test.call(this, this.value) || '';
+      return errMsg;
+    }, this);
+
+    this.message = errMsg;
+    return errMsg;
   },
 
   setValid: function(now, forceFire) {
@@ -94,7 +135,7 @@ var MultiFieldView = View.extend({
     return valid;
   },
 
-  setValue: function(value) {
+  setValue: function(value, skipValidation) {
     var fields = this.fields;
     var findField = function(name) {
       var field = find(fields, {
@@ -112,6 +153,12 @@ var MultiFieldView = View.extend({
       var field = findField(k);
       field.setValue(value[k], !field.required);
     });
+
+    if (!skipValidation) {
+      this.shouldValidate = true;
+    } else if (skipValidation) {
+      this.shouldValidate = false;
+    }
   },
 
   update: function(field) {
@@ -144,6 +191,8 @@ var MultiFieldView = View.extend({
         field.beforeSubmit();
       }
     });
+    this.shouldValidate = true;
+    this.runTests();
   }
 });
 

--- a/ampersand-multifield-view.js
+++ b/ampersand-multifield-view.js
@@ -195,6 +195,9 @@ var MultiFieldView = View.extend({
   },
 
   clear: function() {
+    // This won't unset field values, but will disable validation
+    this.setValue({}, true);
+
     this.fields.forEach(function(field) {
       if(field.clear) {
         field.clear();

--- a/ampersand-multifield-view.js
+++ b/ampersand-multifield-view.js
@@ -154,11 +154,7 @@ var MultiFieldView = View.extend({
       field.setValue(value[k], !field.required);
     });
 
-    if (!skipValidation) {
-      this.shouldValidate = true;
-    } else if (skipValidation) {
-      this.shouldValidate = false;
-    }
+    this.shouldValidate = !skipValidation;
   },
 
   update: function(field) {

--- a/ampersand-multifield-view.js
+++ b/ampersand-multifield-view.js
@@ -62,7 +62,7 @@ var MultiFieldView = View.extend({
     this.name = spec.name;
     this.tests = spec.tests || this.tests || [];
     this.validCallback = spec.validCallback || function() {};
-    this.value = spec.value || {};
+    this.value = this.startingValue = spec.value || {};
 
     this.fields.forEach(function(field) {
       field.parent = this;
@@ -183,6 +183,25 @@ var MultiFieldView = View.extend({
     });
 
     View.prototype.remove.apply(this, arguments);
+  },
+
+  reset: function() {
+    this.setValue(this.startingValue, true);
+    this.fields.forEach(function(field) {
+      if(field.reset) {
+        field.reset();
+      }
+    });
+  },
+
+  clear: function() {
+    this.fields.forEach(function(field) {
+      if(field.clear) {
+        field.clear();
+      } else {
+        field.setValue(null);
+      }
+    });
   },
 
   beforeSubmit: function() {

--- a/ampersand-multifield-view.js
+++ b/ampersand-multifield-view.js
@@ -102,9 +102,7 @@ var MultiFieldView = View.extend({
       return field.valid;
     });
 
-    var valid = !this.runTests();
-
-    return fieldsValid && valid;
+    return fieldsValid && !this.runTests();
   },
 
   runTests: function() {
@@ -191,8 +189,7 @@ var MultiFieldView = View.extend({
   },
 
   clear: function() {
-    // This won't unset field values, but will disable validation
-    this.setValue({}, true);
+    this.shouldValidate = false;
 
     this.fields.forEach(function(field) {
       if(field.clear) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -73,7 +73,9 @@ test('it updates its validity based on its fields', function(t) {
 
 test('it runs given validation tests', function(t) {
   var cb = sinon.spy();
-  makeMultifield({tests: [cb]});
+  var value = {field1: 'test', field2: 'test2'};
+  var multifield = makeMultifield({value: value, tests: [cb]});
+  multifield.render();
 
   t.ok(cb.called, 'tests were called');
   t.end();

--- a/test/basic.js
+++ b/test/basic.js
@@ -155,3 +155,30 @@ test('it handles its validCallback function', function(t) {
   t.ok(cb.called, 'sets and calls the validCallback');
   t.end();
 });
+
+test('it can reset its value', function(t) {
+   var value = {field1: 'test', field2: 'test2'};
+   var value2 = {field1: 'testReset', field2: 'testReset2'};
+   var multifield = makeMultifield({value: value});
+
+   multifield.render();
+   multifield.setValue(value2);
+   multifield.reset();
+
+   t.deepEqual(multifield.value, value, 'resets to the starting value');
+   t.end();
+});
+
+test('it can clear its value', function(t) {
+  var value = {field1: 'test', field2: 'test2'};
+  var multifield = makeMultifield({value: value});
+
+  multifield.render();
+  multifield.clear();
+
+  value.field1 = null;
+  value.field2 = null;
+
+  t.deepEqual(multifield.value, value, 'nullifies the fields\' values');
+  t.end();
+});

--- a/test/basic.js
+++ b/test/basic.js
@@ -63,11 +63,78 @@ test('it updates its validity based on its fields', function(t) {
   var multifield = makeMultifield({value: value});
   multifield.render();
 
-  t.equal(multifield.valid, false, 'with an invalid field');
+  t.notOk(multifield.valid, 'with an invalid field');
 
   multifield.fields[1].setValue('anotherTest');
 
-  t.equal(multifield.valid, true, 'when all fields are valid');
+  t.ok(multifield.valid, 'when all fields are valid');
+  t.end();
+});
+
+test('it runs given validation tests', function(t) {
+  var cb = sinon.spy();
+  makeMultifield({tests: [cb]});
+
+  t.ok(cb.called, 'tests were called');
+  t.end();
+});
+
+test('it is not valid when a validation test fails', function(t) {
+  var cb = sinon.spy(function() {
+    return 'A failure';
+  });
+
+  var value = {field1: 'test', field2: 'test2'};
+  var multifield = makeMultifield({tests: [cb], value: value});
+  multifield.render();
+
+  t.notOk(multifield.updateValid(), 'valid is false when a test fails');
+  t.equal(multifield.message, 'A failure', 'sets the tests\'s error message');
+  t.end();
+});
+
+test('it is valid when validation tests pass', function(t) {
+  var cb = sinon.spy();
+  var value = {field1: 'test', field2: 'test2'};
+  var multifield = makeMultifield({tests: [cb], value: value});
+  multifield.render();
+
+  t.ok(multifield.valid, 'valid is set to true');
+  t.equal(multifield.message, '', 'error message is empty');
+  t.end();
+});
+
+test('hides the error message when valid', function(t) {
+  var cb = sinon.spy();
+  var value = {field1: 'test', field2: 'test2'};
+  var multifield = makeMultifield({tests: [cb], value: value});
+
+  multifield.render();
+
+  var messageContainer = multifield.queryByHook('multi-message-container');
+  var messageText = multifield.queryByHook('multi-message-text');
+  var isHidden = messageContainer.style.display === 'none';
+
+  t.ok(isHidden, 'message is hidden when view is valid');
+  t.notOk(messageText.textContent, 'message is empty');
+  t.end();
+});
+
+test('show the error message when a validation test fails', function(t) {
+  var cb = sinon.spy(function() {
+    return 'A failure';
+  });
+  var value = {field1: 'test', field2: 'test2'};
+  var multifield = makeMultifield({tests: [cb], value: value});
+
+  multifield.render();
+
+  var messageContainer = multifield.queryByHook('multi-message-container');
+  var messageText = multifield.queryByHook('multi-message-text');
+  var isHidden = messageContainer.style.display === 'none';
+
+  t.notOk(isHidden, 'message is hidden when view is valid');
+  t.equal(messageText.textContent, 'A failure', 'displays a message');
   t.end();
 });
 
@@ -85,6 +152,6 @@ test('it handles its validCallback function', function(t) {
   var cb = sinon.spy();
   makeMultifield({validCallback: cb});
 
-  t.equal(cb.called, true, 'sets and calls the validCallback');
+  t.ok(cb.called, 'sets and calls the validCallback');
   t.end();
 });


### PR DESCRIPTION
Fixes https://github.com/yola/ampersand-multifield-view/issues/7
- `tests` is now an option that is array of functions that run validations on the multifield's `value`.
- `clear` can be called to clear all inputs.
- `reset` can be called to reset form to the initial state.
