### PR TITLE
Update `this.value` before `updateValid` call

### DIFF
--- a/ampersand-multifield-view.js
+++ b/ampersand-multifield-view.js
@@ -157,14 +157,13 @@ var MultiFieldView = View.extend({
 
   update: function(field) {
     this.trigger('change:' + field.name, field);
+    this.value[field.name] = field.value;
 
     if (field.valid) {
       this.updateValid();
     } else {
       this.setValid(false);
     }
-
-    this.value[field.name] = field.value;
 
     if (this.parent) {
       this.parent.update(this);


### PR DESCRIPTION
When a child view updates its value, it also runs the multifield's `update` function.

Within `MultiFieldView.update`, `updateValid` would run the tests without the multifield-view's updated `value`. This would cause the tests to be run against the old value, which caused false validation failures.
