### PR TITLE
Version bump 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # 0.1.2
 * Fixed multifield-view's `update` to update its own value before running validation. ([10][10])
 
-[10]: https://github.com/yola/ampersand-multifield-view/pull/8
+[10]: https://github.com/yola/ampersand-multifield-view/pull/10
 
 # 0.1.2
 * Added multifield-level validation. See `AmpersersandMultifieldView.tests`. ([8][8])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-# 0.1.2
+# 0.1.3
 * Fixed multifield-view's `update` to update its own value before running validation. ([10][10])
 
 [10]: https://github.com/yola/ampersand-multifield-view/pull/10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@
 
 [8]: https://github.com/yola/ampersand-multifield-view/pull/8
 
-# 0.1.1 
+# 0.1.1
 * Remove `fields` from `props` so they can be provided when using `extend` ([3][3])
 * Added support to pass in `fields` during instantiation
 
 [3]: https://github.com/yola/ampersand-multifield-view/pull/3
 
-# 0.1.0 
+# 0.1.0
 * Initial implementation ([1][1])
 
 [1]: https://github.com/yola/ampersand-multifield-view/pull/1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
 # 0.1.2
+* Fixed multifield-view's `update` to update its own value before running validation. ([10][10])
+
+[10]: https://github.com/yola/ampersand-multifield-view/pull/8
+
+# 0.1.2
 * Added multifield-level validation. See `AmpersersandMultifieldView.tests`. ([8][8])
 * Added `reset` and `clear` functions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ampersand-multifield-view",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A view module for intelligently grouping multiple field views. Works well with ampersand-form-view",
   "main": "ampersand-multifield-view.js",
   "scripts": {


### PR DESCRIPTION
- Fixed multifield-view's `update` to update its own value before running validation. https://github.com/yola/ampersand-multifield-view/pull/10
- Remove some trailing whitespace from the changelog
