### PR TITLE
Version bump to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ampersand-multifield-view",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A view module for intelligently grouping multiple field views. Works well with ampersand-form-view",
   "main": "ampersand-multifield-view.js",
   "scripts": {


### PR DESCRIPTION
Messed up the npm publishing. npm published 0.1.3 wrong, and tried to unpublish/republish. However didn't know that you can't do that, so now to fix it, this repo is version bumped again to 0.1.4.
