### PR TITLE
Call `isValid` instead of `runTests` in `beforeSubmit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 0.1.5
+* Fixed multifield-view's `beforeSubmit` to call `isValid` instead of `runTests` to enforce fields' validity before running multifield tests. ([13][13])
+
+[13]: https://github.com/yola/ampersand-multifield-view/pull/13
+
 # 0.1.3
 * Fixed multifield-view's `update` to update its own value before running validation. ([10][10])
 

--- a/ampersand-multifield-view.js
+++ b/ampersand-multifield-view.js
@@ -206,7 +206,7 @@ var MultiFieldView = View.extend({
       }
     });
     this.shouldValidate = true;
-    this.runTests();
+    this.isValid();
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ampersand-multifield-view",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A view module for intelligently grouping multiple field views. Works well with ampersand-form-view",
   "main": "ampersand-multifield-view.js",
   "scripts": {


### PR DESCRIPTION
`isValid` will check the fields' validity before running tests, meaning
one can correctly assume that that the multifield-view's tests will run
on valid fields.
