### PR TITLE
Update dependencies to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
-  - '4.2'
-  - '5.5'
+  - '4'
+  - '5'
 
 install:
   - npm install

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   "homepage": "https://github.com/yola/ampersand-multifield-view",
   "devDependencies": {
     "ampersand-view-conventions": "^1.1.8",
-    "browserify": "^10.2.3",
+    "browserify": "^13.0.0",
     "jsgreat": "^0.1.6",
     "lodash.assign": "^3.2.0",
-    "phantomjs": "^1.9.17",
+    "phantomjs-prebuilt": "^2.1.3",
     "sinon": "^1.14.1",
     "tap-spec": "^4.0.0",
     "tape": "^4.0.0",
@@ -34,7 +34,7 @@
     "tape-suite": "^0.2.1"
   },
   "dependencies": {
-    "ampersand-view": "^7.4.2",
-    "lodash.find": "^3.2.1"
+    "ampersand-view": "^9.0.2",
+    "lodash.find": "^4.1.0"
   }
 }


### PR DESCRIPTION
The following break travis, but pass tests locally:
- lodash.assign
- tape-run
