### PR TITLE
Bump to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.1.8
+## 0.2.0
 * Upgrade to ampersand-view@10
 * Swap lodash.find for lodash
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ampersand-multifield-view",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "A view module for intelligently grouping multiple field views. Works well with ampersand-form-view",
   "main": "ampersand-multifield-view.js",
   "scripts": {


### PR DESCRIPTION
Goofed, accidentally pushed to master a bump to 0.1.8, but that's not what I wanted.

There are a handful of dev versions like: `0.2.0-dev.1` and this will be the official release for those dev tags.